### PR TITLE
chore: dockerfile: Remove duplicating build steps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ RUN \
 
 COPY . .
 RUN touch src/main.rs
-RUN cargo build --release -v
 RUN cargo install --path .
 
 FROM debian:bookworm-slim


### PR DESCRIPTION
build and install both build, but Docker seems to spend a bunch of time on install that may not be necessary to do both build and install

Maybe this will be faster? 