### PR TITLE
chore: workflow: Don't build docker on GH release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,6 @@
 name: Docker Release
 
 on:
-  release:
-    types: [published]
   push:
     tags:
       - "*"


### PR DESCRIPTION
The tag push is enough to build the docker image and push a tagged version. The release build is extra/useless work