### PR TITLE
feat: Sync in background

### DIFF
--- a/.sqlx/query-3f4d38c6f5950a4369d19ada7ad54655bcea70892acb86c23f90438541fd0c95.json
+++ b/.sqlx/query-3f4d38c6f5950a4369d19ada7ad54655bcea70892acb86c23f90438541fd0c95.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n    INSERT INTO simplefin_connection_sync_info ( connection_id, ts )\n    VALUES ( $1, $2 )\n    ON CONFLICT (connection_id, ts) DO NOTHING\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Timestamp"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "3f4d38c6f5950a4369d19ada7ad54655bcea70892acb86c23f90438541fd0c95"
+}

--- a/.sqlx/query-b321461e42429160613fc5db4f6d6fc2c62bd8ac329d3652ff279a0f0e1c2fbe.json
+++ b/.sqlx/query-b321461e42429160613fc5db4f6d6fc2c62bd8ac329d3652ff279a0f0e1c2fbe.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT connection_id, ts FROM simplefin_connection_sync_info\n        WHERE connection_id = $1\n        ORDER BY ts DESC\n        LIMIT 1;\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "connection_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "ts",
+        "type_info": "Timestamp"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "b321461e42429160613fc5db4f6d6fc2c62bd8ac329d3652ff279a0f0e1c2fbe"
+}

--- a/schema/simplefin.hcl
+++ b/schema/simplefin.hcl
@@ -17,6 +17,31 @@ table "simplefin_connections" {
   }
 }
 
+table "simplefin_connection_sync_info" {
+  schema = schema.public
+
+  column "connection_id" {
+    type = uuid
+  }
+  column "ts" {
+    type = timestamp
+  }
+
+  primary_key {
+    columns = [
+      column.connection_id,
+      column.ts,
+    ]
+  }
+
+  foreign_key "simplefin_connection" {
+    columns = [column.connection_id]
+    ref_columns = [table.simplefin_connections.column.id]
+    on_delete = CASCADE
+    on_update = NO_ACTION
+  }
+}
+
 table "simplefin_accounts" {
   schema = schema.public
 

--- a/src/sync_manager.rs
+++ b/src/sync_manager.rs
@@ -1,0 +1,70 @@
+use crate::{AppState, SFAccount, SFAccountBalance, SFAccountTransaction, SFConnection};
+use std::time::Duration;
+use tokio::time::sleep;
+use tracing::Level;
+
+pub async fn sync_all(app_state: AppState) -> () {
+    loop {
+        let res = try_sync_all(&app_state).await;
+        if let Err(e) = res {
+            tracing::event!(Level::ERROR, error = e.to_string(), "Could not sync");
+        }
+        sleep(Duration::from_secs(60 * 60)).await;
+    }
+}
+
+#[tracing::instrument(name = "sync_connections", skip_all)]
+async fn try_sync_all(app_state: &AppState) -> anyhow::Result<()> {
+    for conn in SFConnection::connections(&app_state.db_spike).await? {
+        tracing::event!(
+            Level::INFO,
+            connection_id = conn.id.to_string(),
+            "Syncing connection"
+        );
+        sync_connection(&app_state, &conn).await?;
+    }
+    Ok(())
+}
+
+#[tracing::instrument(skip_all, fields(connection_id=sfc.id.to_string()))]
+async fn sync_connection(app_state: &AppState, sfc: &SFConnection) -> anyhow::Result<()> {
+    if let Some(sync_info) = sfc.last_sync_info(&app_state.db_spike).await? {
+        if sync_info.is_since(chrono::Duration::hours(4)) {
+            tracing::event!(
+                Level::INFO,
+                connection_id = sfc.id.to_string(),
+                "Connection synchronized recently, not attempting to sync"
+            );
+            return Ok(());
+        }
+    }
+
+    let account_set = crate::simplefin_api::accounts(&sfc.access_url).await?;
+    for account in account_set.accounts {
+        tracing::debug!(account_id = account.id, "Saving account");
+        let sfa = SFAccount {
+            id: account.id,
+            connection_id: sfc.id,
+            name: account.name,
+            currency: account.currency,
+        };
+        sfa.ensure_in_db(&app_state.db).await?;
+        let sfab = SFAccountBalance {
+            account_id: sfa.id.clone(),
+            connection_id: sfc.id,
+            timestamp: account.balance_date,
+            balance: account.balance,
+        };
+        sfab.ensure_in_db(&app_state.db).await?;
+
+        let txs_f = account.transactions.iter().map(|src_tx| {
+            let tx = SFAccountTransaction::from_transaction(&sfa, &src_tx);
+            SFAccountTransaction::ensure_in_db(tx, &app_state.db_spike)
+        });
+
+        futures::future::try_join_all(txs_f).await?;
+        ()
+    }
+    sfc.mark_synced(&app_state.db_spike).await?;
+    Ok(())
+}


### PR DESCRIPTION
Run the connection sync process in the background.

Future work should display sync info to the user, currently the last sync time. Eventually the sync messages can be attached to the last sync ts for display as well