### PR TITLE
feat: Disable individual accounts from syncing

### DIFF
--- a/.sqlx/query-116c75c5f3fcd22728352fe1300b0c5e121b4af1ee0be5a6dd7ca502e10fac44.json
+++ b/.sqlx/query-116c75c5f3fcd22728352fe1300b0c5e121b4af1ee0be5a6dd7ca502e10fac44.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n    INSERT INTO simplefin_accounts ( connection_id, simplefin_id, name, currency )\n    VALUES ( $1, $2, $3, $4 )\n    ON CONFLICT (connection_id, simplefin_id) DO UPDATE set name = EXCLUDED.name\n    RETURNING id, connection_id, currency, name\n            ",
+  "query": "\n        SELECT id, connection_id, currency, name, active\n        FROM simplefin_accounts\n        WHERE id = $1\n            ",
   "describe": {
     "columns": [
       {
@@ -22,22 +22,25 @@
         "ordinal": 3,
         "name": "name",
         "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "active",
+        "type_info": "Bool"
       }
     ],
     "parameters": {
       "Left": [
-        "Uuid",
-        "Varchar",
-        "Varchar",
-        "Varchar"
+        "Uuid"
       ]
     },
     "nullable": [
       false,
       false,
       false,
+      false,
       false
     ]
   },
-  "hash": "0705826f6ff427c9abbf960886ce564650d2ac032d048321b81ff4c30cd64c36"
+  "hash": "116c75c5f3fcd22728352fe1300b0c5e121b4af1ee0be5a6dd7ca502e10fac44"
 }

--- a/.sqlx/query-1e2c81c03817cf319edebcf8c2ecd66e2a9fd4960e01f151a1ec3a259666ec3a.json
+++ b/.sqlx/query-1e2c81c03817cf319edebcf8c2ecd66e2a9fd4960e01f151a1ec3a259666ec3a.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        UPDATE simplefin_accounts\n        SET active = false\n        WHERE id = $1\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "1e2c81c03817cf319edebcf8c2ecd66e2a9fd4960e01f151a1ec3a259666ec3a"
+}

--- a/.sqlx/query-90ac377c517ab76660718184e7a575833eef438c5d198cefa8463e0f6661b869.json
+++ b/.sqlx/query-90ac377c517ab76660718184e7a575833eef438c5d198cefa8463e0f6661b869.json
@@ -1,0 +1,49 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n    INSERT INTO simplefin_accounts ( connection_id, simplefin_id, name, currency )\n    VALUES ( $1, $2, $3, $4 )\n    ON CONFLICT (connection_id, simplefin_id) DO UPDATE set name = EXCLUDED.name\n    RETURNING id, connection_id, currency, name, active\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "connection_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "currency",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "active",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Varchar",
+        "Varchar",
+        "Varchar"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "90ac377c517ab76660718184e7a575833eef438c5d198cefa8463e0f6661b869"
+}

--- a/.sqlx/query-a66833f742a525801b6ebe9a9050cf994fbce91b63d6b4de6fa02897669ede03.json
+++ b/.sqlx/query-a66833f742a525801b6ebe9a9050cf994fbce91b63d6b4de6fa02897669ede03.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        UPDATE simplefin_accounts\n        SET active = true\n        WHERE id = $1\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "a66833f742a525801b6ebe9a9050cf994fbce91b63d6b4de6fa02897669ede03"
+}

--- a/.sqlx/query-dfbb6e8b55ca51d0f8e614dd3bc6935fbf96d848897f7e7de4cbeadd9f5ecfca.json
+++ b/.sqlx/query-dfbb6e8b55ca51d0f8e614dd3bc6935fbf96d848897f7e7de4cbeadd9f5ecfca.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        DELETE\n        FROM simplefin_account_transactions\n        WHERE account_id = $1\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "dfbb6e8b55ca51d0f8e614dd3bc6935fbf96d848897f7e7de4cbeadd9f5ecfca"
+}

--- a/.sqlx/query-fe792083a5e59b2f1c716d25e5e42bae129c15b1d8d320963a1dbf176c8c226a.json
+++ b/.sqlx/query-fe792083a5e59b2f1c716d25e5e42bae129c15b1d8d320963a1dbf176c8c226a.json
@@ -1,0 +1,44 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT id, connection_id, currency, name, active\n        FROM simplefin_accounts\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "connection_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "currency",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "active",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "fe792083a5e59b2f1c716d25e5e42bae129c15b1d8d320963a1dbf176c8c226a"
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -962,6 +962,7 @@ dependencies = [
  "chrono",
  "clap",
  "futures",
+ "http 1.1.0",
  "maud",
  "once_cell",
  "reqwest 0.12.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,4 @@ rust_decimal = { version = "1.35.0", features = ["db-postgres", "serde-float"] }
 rust-embed = { version = "8.3.0", features = ["axum", "mime-guess", "mime_guess"] }
 axum-embed = "0.1.0"
 axum-extra = { version = "0.9.3", features = ["query"] }
+http = "1.1.0"

--- a/schema/simplefin.hcl
+++ b/schema/simplefin.hcl
@@ -26,7 +26,6 @@ table "simplefin_connection_sync_info" {
   column "ts" {
     type = timestamptz
   }
-
   primary_key {
     columns = [
       column.connection_id,
@@ -89,6 +88,11 @@ table "simplefin_accounts" {
   column "currency" {
     type = varchar
   }
+  column "active" {
+    type = bool
+    default = true
+  }
+
   primary_key {
     columns = [
       column.id,

--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -1,4 +1,11 @@
+use crate::{AppError, AppState};
 use sqlx::postgres::PgPool;
+
+use axum::{
+    extract::{FromRef, Path, State},
+    response::{IntoResponse, Response},
+    Form,
+};
 
 pub type AccountID = uuid::Uuid;
 #[derive(Debug)]
@@ -17,7 +24,7 @@ impl SFAccount {
     INSERT INTO simplefin_accounts ( connection_id, simplefin_id, name, currency )
     VALUES ( $1, $2, $3, $4 )
     ON CONFLICT (connection_id, simplefin_id) DO UPDATE set name = EXCLUDED.name
-    RETURNING id, connection_id, currency, name
+    RETURNING id, connection_id, currency, name, active
             "#,
             self.connection_id,
             self.simplefin_id,
@@ -31,11 +38,13 @@ impl SFAccount {
     }
 }
 
+#[derive(Clone, Debug, serde::Deserialize)]
 pub struct Account {
     pub id: AccountID,
     pub connection_id: crate::ConnectionID,
     pub currency: String,
     pub name: String,
+    pub active: bool,
 }
 
 pub struct SFAccountBalanceQueryResult {
@@ -69,6 +78,97 @@ impl SFAccountBalanceQueryResult {
     }
 }
 
+impl Account {
+    #[tracing::instrument]
+    pub async fn get_all(pool: &PgPool) -> anyhow::Result<Vec<Self>> {
+        let res = sqlx::query_as!(
+            Self,
+            r#"
+        SELECT id, connection_id, currency, name, active
+        FROM simplefin_accounts
+            "#,
+        )
+        .fetch_all(pool)
+        .await?;
+
+        Ok(res)
+    }
+    pub async fn get(account_id: AccountID, pool: &PgPool) -> anyhow::Result<Option<Self>> {
+        let res = sqlx::query_as!(
+            Self,
+            r#"
+        SELECT id, connection_id, currency, name, active
+        FROM simplefin_accounts
+        WHERE id = $1
+            "#,
+            account_id
+        )
+        .fetch_optional(pool)
+        .await?;
+
+        Ok(res)
+    }
+
+    pub async fn enable_sync(account_id: AccountID, pool: &PgPool) -> anyhow::Result<()> {
+        sqlx::query!(
+            r#"
+        UPDATE simplefin_accounts
+        SET active = true
+        WHERE id = $1
+            "#,
+            account_id
+        )
+        .execute(pool)
+        .await?;
+
+        Ok(())
+    }
+
+    pub async fn disable_sync(account_id: AccountID, pool: &PgPool) -> anyhow::Result<()> {
+        sqlx::query!(
+            r#"
+        UPDATE simplefin_accounts
+        SET active = false
+        WHERE id = $1
+            "#,
+            account_id
+        )
+        .execute(pool)
+        .await?;
+
+        Ok(())
+    }
+
+    pub fn render_edit(&self) -> maud::Markup {
+        maud::html!( {
+            div #{"account-" (self.id)}{
+            (self.id)
+                {
+                @if self.active {
+                    div
+                        hx-delete={"/f/accounts/" (self.id) "/active"}
+                        hx-target={"#account-" (self.id)}
+                        hx-trigger="click"
+                        { "Sync enabled. [CLICK HERE] to disable"}
+                } @else {
+                    div
+                        hx-post={"/f/accounts/" (self.id) "/active"}
+                        hx-target={"#account-" (self.id)}
+                        hx-trigger="click"
+                        { "Sync disabled. [CLICK HERE] to enable"}
+                }
+                div
+                    hx-post={"/f/accounts/" (self.id) "/delete-transactions"}
+                    hx-target={"#account-" (self.id)}
+                    hx-confirm="Delete all accounts?"
+                    hx-trigger="click"
+                    { "DELETE ALL TRANSACTIONS (requires confirmation)"}
+
+            }}
+        })
+    }
+}
+
 #[derive(Debug)]
 pub struct SFAccountBalance {
     pub account_id: AccountID,
@@ -92,5 +192,105 @@ impl SFAccountBalance {
         .await?;
 
         Ok(())
+    }
+}
+
+#[derive(serde::Deserialize, Clone, Debug)]
+pub struct AccountIDFilter {
+    pub account_id: AccountID,
+}
+
+pub async fn get_accounts_f(
+    State(app_state): State<AppState>,
+    _user: service_conventions::oidc::OIDCUser,
+) -> Result<Response, AppError> {
+    let accounts = Account::get_all(&app_state.db).await?;
+    let resp = maud::html! {
+        @for account in accounts {
+            (account.render_edit())
+        }
+
+    };
+    Ok(resp.into_response())
+}
+
+fn render_maybe_edit(maybe_account: Option<Account>) -> Result<Response, AppError> {
+    if let Some(account) = maybe_account {
+        let resp = maud::html! {
+            (account.render_edit())
+        }
+        .into_response();
+        Ok(resp)
+    } else {
+        Ok((http::StatusCode::NOT_FOUND, format!("Not Found")).into_response())
+    }
+}
+
+pub async fn get_account_f(
+    State(app_state): State<AppState>,
+    _user: service_conventions::oidc::OIDCUser,
+    Path(params): Path<AccountIDFilter>,
+) -> Result<Response, AppError> {
+    let account_id = params.account_id;
+    let maybe_account = Account::get(account_id, &app_state.db).await?;
+    render_maybe_edit(maybe_account)
+}
+pub async fn handle_active_post(
+    State(app_state): State<AppState>,
+    _user: service_conventions::oidc::OIDCUser,
+    Path(params): Path<AccountIDFilter>,
+) -> Result<Response, AppError> {
+    let account_id = params.account_id;
+    Account::enable_sync(account_id, &app_state.db).await?;
+    let maybe_account = Account::get(account_id, &app_state.db).await?;
+    render_maybe_edit(maybe_account)
+}
+
+pub async fn handle_active_delete(
+    State(app_state): State<AppState>,
+    _user: service_conventions::oidc::OIDCUser,
+    Path(params): Path<AccountIDFilter>,
+) -> Result<Response, AppError> {
+    let account_id = params.account_id;
+    Account::disable_sync(account_id, &app_state.db).await?;
+    let maybe_account = Account::get(account_id, &app_state.db).await?;
+    render_maybe_edit(maybe_account)
+}
+
+pub async fn handle_delete_transactions(
+    State(app_state): State<AppState>,
+    _user: service_conventions::oidc::OIDCUser,
+    Path(params): Path<AccountIDFilter>,
+) -> Result<Response, AppError> {
+    let account_id = params.account_id;
+    crate::tx::AccountTransaction::delete_for_account(account_id, &app_state.db).await?;
+    let maybe_account = Account::get(account_id, &app_state.db).await?;
+    render_maybe_edit(maybe_account)
+}
+
+pub async fn get_account(
+    State(app_state): State<AppState>,
+    _user: service_conventions::oidc::OIDCUser,
+    Path(params): Path<AccountIDFilter>,
+) -> Result<Response, AppError> {
+    let account_id = params.account_id;
+    let maybe_account_f = Account::get(account_id, &app_state.db);
+
+    let user_connections_f = crate::Connection::connections(&app_state.db);
+    let balances_f = SFAccountBalanceQueryResult::get_balances(&app_state.db);
+    let (user_connections, balances, maybe_account) =
+        futures::try_join!(user_connections_f, balances_f, maybe_account_f)?;
+    if let Some(account) = maybe_account {
+        Ok(crate::html::maud_page(maud::html! {
+              div class="flex flex-col lg:flex-row"{
+              (crate::html::sidebar(user_connections, balances))
+              div #main class="main" {
+                    (account.render_edit())
+              }}
+
+        })
+        .into_response())
+    } else {
+        Ok((http::StatusCode::NOT_FOUND, format!("Not Found")).into_response())
     }
 }

--- a/src/html.rs
+++ b/src/html.rs
@@ -1,3 +1,4 @@
+use crate::svg_icon;
 use maud::{html, DOCTYPE};
 
 pub fn maud_page(content: maud::Markup) -> maud::Markup {
@@ -90,6 +91,7 @@ pub fn sidebar(
               thead {
                 tr
                 {
+                    th {}
                     th { "Account"}
                     th { "Balance"}
                 }
@@ -97,14 +99,27 @@ pub fn sidebar(
               tbody {
               @for balance in &balances {
               tr
-                  hx-get={"/f/transactions?account_id=" (balance.account_id) }
-                  hx-push-url={"/?account_id=" (balance.account_id) }
-                  hx-target="#main"
-                  hx-swap="innerHTML"
-                  hx-trigger="click"
                   {
-                  td { (balance.name)}
-                  td { (balance.balance.to_decimal(2))}
+                  td
+                    hx-get={"/f/transactions?account_id=" (balance.account_id) }
+                    hx-push-url={"/?account_id=" (balance.account_id) }
+                    hx-target="#main"
+                    hx-swap="innerHTML"
+                    hx-trigger="click"
+                    class="peer"
+                    { (balance.name)}
+
+                  td
+                    class="peer"
+                    { (balance.balance.to_decimal(2))}
+                  td
+                    hx-get={"/f/accounts/" (balance.account_id) }
+                    hx-push-url={"/accounts/" (balance.account_id) }
+                    hx-target="#main"
+                    hx-swap="innerHTML"
+                    hx-trigger="click"
+                    class="invisible peer-hover:visible hover:visible"
+                    { (svg_icon::pencil_square())}
               }
               }
               }

--- a/src/svg_icon.rs
+++ b/src/svg_icon.rs
@@ -24,6 +24,44 @@ pub fn exclamation_circle() -> Markup {
     }
 }
 
+pub fn pencil_square() -> Markup {
+    html! {
+        svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+            class=(default_hw())
+        {
+            path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10"
+                {}
+        }
+    }
+}
+
+pub fn funnel() -> Markup {
+    html! {
+        svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+            class=(default_hw())
+        {
+            path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M12 3c2.755 0 5.455.232 8.083.678.533.09.917.556.917 1.096v1.044a2.25 2.25 0 0 1-.659 1.591l-5.432 5.432a2.25 2.25 0 0 0-.659 1.591v2.927a2.25 2.25 0 0 1-1.244 2.013L9.75 21v-6.568a2.25 2.25 0 0 0-.659-1.591L3.659 7.409A2.25 2.25 0 0 1 3 5.818V4.774c0-.54.384-1.006.917-1.096A48.32 48.32 0 0 1 12 3Z"
+                {}
+        }
+    }
+}
+
 pub fn x_circle() -> Markup {
     html! {
         svg

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -53,9 +53,6 @@ impl SFAccountTXQueryResultRow {
         td {
               div {
                   form
-                        action="/f/labels/search-and-apply-first"
-                        method="post"
-                        hx-from="input"
                         hx-get="/f/labels/search"
                         hx-target={"#search-results-" (self.id)}
                         hx-trigger="input changed delay:100ms from:input"
@@ -401,6 +398,26 @@ pub struct AccountTransaction {
     amount: sqlx::postgres::types::PgMoney,
     pending: Option<bool>,
     description: String,
+}
+
+impl AccountTransaction {
+    pub async fn delete_for_account(
+        account_id: crate::accounts::AccountID,
+        pool: &PgPool,
+    ) -> anyhow::Result<()> {
+        sqlx::query!(
+            r#"
+        DELETE
+        FROM simplefin_account_transactions
+        WHERE account_id = $1
+            "#,
+            account_id
+        )
+        .execute(pool)
+        .await?;
+
+        Ok(())
+    }
 }
 
 impl SFAccountTransaction {


### PR DESCRIPTION
And be able to delete all transactions

I added my a new bank connection in SimpleFin that has joint banking accounts with an existing bank connection. This lead to duplicate transactions showing up from SimpleFin. A relatively quick way to deal with this is to disable syncing of particular accounts and remove any transactions that were part of that account.

The account still comes through in SimpleFin, so don't save the updated balance or any transactions when fetched.

A future net-worth display should only look for balances within some recent time period / only active accounts