### PR TITLE
feat: Filter transactions by fulltext

### DIFF
--- a/.sqlx/query-6383cbe1e8f0d23f7ef8a0423cbc6d4fcc25357377942fcd0a9ec7fed117f875.json
+++ b/.sqlx/query-6383cbe1e8f0d23f7ef8a0423cbc6d4fcc25357377942fcd0a9ec7fed117f875.json
@@ -1,0 +1,53 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT sat.posted, sat.transacted_at, sat.amount, sat.description, sat.account_id, sat.id\n        FROM simplefin_account_transactions sat\n        WHERE sat.description LIKE $1\n        AND sat.posted >= $2\n        ORDER BY\n            sat.posted DESC\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "posted",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 1,
+        "name": "transacted_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 2,
+        "name": "amount",
+        "type_info": "Money"
+      },
+      {
+        "ordinal": 3,
+        "name": "description",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "account_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 5,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Timestamptz"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "6383cbe1e8f0d23f7ef8a0423cbc6d4fcc25357377942fcd0a9ec7fed117f875"
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -970,6 +970,7 @@ dependencies = [
  "rust_decimal",
  "serde",
  "serde_json",
+ "serde_qs",
  "service_conventions",
  "signal-hook",
  "sqlx",
@@ -3065,6 +3066,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ce1fc6db65a611022b23a0dec6975d63fb80a302cb3388835ff02c097258d50"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_qs"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd34f36fe4c5ba9654417139a9b3a20d2e1de6012ee678ad14d240c22c78d8d6"
+dependencies = [
+ "percent-encoding",
+ "serde",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,4 @@ rust-embed = { version = "8.3.0", features = ["axum", "mime-guess", "mime_guess"
 axum-embed = "0.1.0"
 axum-extra = { version = "0.9.3", features = ["query"] }
 http = "1.1.0"
+serde_qs = "0.13.0"


### PR DESCRIPTION
Start moving the filtering to use types a bit better. The filter should also eventually serialize to the query string so that it can easily be passed through to future calls and or modified for changes as queries change these things

Add in filtering by text.