### PR TITLE
fix: Connection info loading

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -53,12 +53,12 @@ pub fn sidebar(
           @for sfconn in &user_connections {
           div
 
-              hx-get={"/f/connection/" (sfconn.id) }
+              hx-get={"/f/connection/" (sfconn.id.0) }
               hx-target="this"
               hx-swap="innerHTML"
               hx-trigger="load"
               {
-                (sfconn.id)
+                (sfconn.id.0)
               }
           }
           div {


### PR DESCRIPTION
The switch to newtype broke generation of the URL path required to load the connection info