### PR TITLE
fix: Adjust chart margins to show numbers

### DIFF
--- a/src/charts.rs
+++ b/src/charts.rs
@@ -56,6 +56,8 @@ pub async fn get_chart(
     let mut chart = LineChart::new_with_theme(vec![("vals", vals).into()], dates, THEME_GRAFANA);
     chart.width = chart_options.x_size.0 as f32;
     chart.height = chart_options.y_size.0 as f32;
+    chart.margin.left = 15.0;
+    chart.margin.right = 15.0;
     //bar_chart.title_text = "Mixed Line and Bar".to_string();
     //bar_chart.legend_margin = Some(Box {
     //    top: bar_chart.title_height,


### PR DESCRIPTION
They were being cut off

15.0 works through some trial and error with local data