### PR TITLE
fix: Attempt to make spans from a w3c tracecontext

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -855,7 +855,7 @@ dependencies = [
  "futures",
  "serde",
  "serde_json",
- "service_conventions",
+ "service_conventions 0.0.16",
  "sqlparser",
  "sqlx",
  "thiserror",
@@ -1037,7 +1037,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_qs",
- "service_conventions",
+ "service_conventions 0.0.17",
  "signal-hook",
  "sqlx",
  "thiserror",
@@ -2131,6 +2131,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b69a91d4893e713e06f724597ad630f1fa76057a5e1026c0ca67054a9032a76"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror",
+]
+
+[[package]]
 name = "opentelemetry-http"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2139,7 +2153,20 @@ dependencies = [
  "async-trait",
  "bytes",
  "http 0.2.12",
- "opentelemetry",
+ "opentelemetry 0.22.0",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0ba633e55c5ea6f431875ba55e71664f2fa5d3a90bd34ec9302eecc41c865dd"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 0.2.12",
+ "opentelemetry 0.23.0",
+ "reqwest 0.11.27",
 ]
 
 [[package]]
@@ -2151,11 +2178,31 @@ dependencies = [
  "async-trait",
  "futures-core",
  "http 0.2.12",
- "opentelemetry",
- "opentelemetry-http",
- "opentelemetry-proto",
- "opentelemetry-semantic-conventions",
- "opentelemetry_sdk",
+ "opentelemetry 0.22.0",
+ "opentelemetry-http 0.11.1",
+ "opentelemetry-proto 0.5.0",
+ "opentelemetry-semantic-conventions 0.14.0",
+ "opentelemetry_sdk 0.22.1",
+ "prost",
+ "reqwest 0.11.27",
+ "thiserror",
+ "tokio",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a94c69209c05319cdf7460c6d4c055ed102be242a0a6245835d7bc42c6ec7f54"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "http 0.2.12",
+ "opentelemetry 0.23.0",
+ "opentelemetry-http 0.12.0",
+ "opentelemetry-proto 0.6.0",
+ "opentelemetry_sdk 0.23.0",
  "prost",
  "reqwest 0.11.27",
  "thiserror",
@@ -2169,8 +2216,20 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8fddc9b68f5b80dae9d6f510b88e02396f006ad48cac349411fbecc80caae4"
 dependencies = [
- "opentelemetry",
- "opentelemetry_sdk",
+ "opentelemetry 0.22.0",
+ "opentelemetry_sdk 0.22.1",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "984806e6cf27f2b49282e2a05e288f30594f3dbc74eb7a6e99422bc48ed78162"
+dependencies = [
+ "opentelemetry 0.23.0",
+ "opentelemetry_sdk 0.23.0",
  "prost",
  "tonic",
 ]
@@ -2180,6 +2239,12 @@ name = "opentelemetry-semantic-conventions"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9ab5bd6c42fb9349dcf28af2ba9a0667f697f9bdcca045d39f2cec5543e2910"
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1869fb4bb9b35c5ba8a1e40c9b128a7b4c010d07091e864a29da19e4fe2ca4d7"
 
 [[package]]
 name = "opentelemetry_sdk"
@@ -2194,7 +2259,29 @@ dependencies = [
  "futures-util",
  "glob",
  "once_cell",
- "opentelemetry",
+ "opentelemetry 0.22.0",
+ "ordered-float 4.2.1",
+ "percent-encoding",
+ "rand",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae312d58eaa90a82d2e627fd86e075cf5230b3f11794e2ed74199ebbe572d4fd"
+dependencies = [
+ "async-trait",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "lazy_static",
+ "once_cell",
+ "opentelemetry 0.23.0",
  "ordered-float 4.2.1",
  "percent-encoding",
  "rand",
@@ -3283,6 +3370,21 @@ version = "0.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1307d60806fb58728efeb6745297c5365e0a6a0e10e54f1f8bfa778f5ac471"
 dependencies = [
+ "opentelemetry 0.22.0",
+ "opentelemetry-otlp 0.15.0",
+ "opentelemetry-semantic-conventions 0.14.0",
+ "opentelemetry_sdk 0.22.1",
+ "tracing",
+ "tracing-opentelemetry 0.23.0",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "service_conventions"
+version = "0.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0ed26df4f168d7ab57fba6da5287c73ceedbcedd100373dc4d934d3591d7a39"
+dependencies = [
  "anyhow",
  "async-trait",
  "axum 0.7.5",
@@ -3292,16 +3394,17 @@ dependencies = [
  "maud",
  "once_cell",
  "openidconnect",
- "opentelemetry",
- "opentelemetry-otlp",
- "opentelemetry-semantic-conventions",
- "opentelemetry_sdk",
+ "opentelemetry 0.23.0",
+ "opentelemetry-otlp 0.16.0",
+ "opentelemetry-semantic-conventions 0.15.0",
+ "opentelemetry_sdk 0.23.0",
  "redacted",
  "serde",
  "serde_json",
  "tower-cookies",
+ "tower-http",
  "tracing",
- "tracing-opentelemetry",
+ "tracing-opentelemetry 0.24.0",
  "tracing-subscriber",
  "url",
 ]
@@ -4165,8 +4268,26 @@ checksum = "a9be14ba1bbe4ab79e9229f7f89fab8d120b865859f10527f31c033e599d2284"
 dependencies = [
  "js-sys",
  "once_cell",
- "opentelemetry",
- "opentelemetry_sdk",
+ "opentelemetry 0.22.0",
+ "opentelemetry_sdk 0.22.1",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f68803492bf28ab40aeccaecc7021096bd256baf7ca77c3d425d89b35a7be4e4"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry 0.23.0",
+ "opentelemetry_sdk 0.23.0",
  "smallvec",
  "tracing",
  "tracing-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ tracing = "0.1.40"
 
 url = "2.5.0"
 signal-hook = "0.3.17"
-service_conventions = { version = "0.0.16", features = ["tracing", "oidc"]}
+service_conventions = { version = "0.0.17", features = ["tracing", "oidc", "tracing-http"]}
 sqlx = { version = "0.7.4", features = ["runtime-tokio", "tls-rustls", "postgres", "macros", "uuid", "time", "chrono", "rust_decimal"] }
 base64 = "0.22.1"
 reqwest = { version = "0.12.4", features = ["rustls-tls", "json"] }

--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,7 @@
                 pkgs.openssl # native-tls is included in cargo, needs work to remove
                 pkgs.foreman
                 pkgs.tailwindcss
+                pkgs.opentelemetry-collector
             ] ++
               pkgs.lib.optionals pkgs.stdenv.isDarwin [
                 darwin.apple_sdk.frameworks.Security # Should only be for darwin

--- a/src/main.rs
+++ b/src/main.rs
@@ -304,9 +304,6 @@ impl From<service_conventions::oidc::OIDCUser> for ETUser {
     }
 }
 
-use tower_http::trace::{self, TraceLayer};
-use tracing::Level;
-
 #[tokio::main]
 async fn main() {
     let args = Args::parse();
@@ -386,11 +383,7 @@ async fn main() {
         .with_state(app_state.clone())
         .layer(CookieManagerLayer::new())
         .layer(tower_http::compression::CompressionLayer::new())
-        .layer(
-            TraceLayer::new_for_http()
-                .make_span_with(trace::DefaultMakeSpan::new().level(Level::INFO))
-                .on_response(trace::DefaultOnResponse::new().level(Level::INFO)),
-        )
+        .layer(service_conventions::tracing_http::trace_layer(tracing::Level::INFO))
         .route("/_health", get(health));
 
     let addr: SocketAddr = args.bind_addr.parse().expect("Expected bind addr");


### PR DESCRIPTION
Attach a W3C tracingcontext to the tracing span

This should enable distributed tracing, at least for an incoming request. It does not handle passing the remote context to downstream service calls. 