### PR TITLE
chore: Set sqlx development envvars for the DB

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+DATABASE_URL="postgres://et@localhost/et?sslmode=disable"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -33,7 +33,7 @@ jobs:
     with:
       flakes-from-devshell: true
       script: |
-        unset DATABASE_URL
+        export SQLX_OFFLINE=true
         cargo build
 
   database:
@@ -65,6 +65,6 @@ jobs:
         with:
           flakes-from-devshell: true
           script: |
-            unset DATABASE_URL
+            export SQLX_OFFLINE=true
             cargo build --bin et-migrate
             cargo run --bin et-migrate -- --config-file="config.github-actions.toml" migrate

--- a/.github/workflows/push_main.yml
+++ b/.github/workflows/push_main.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           flakes-from-devshell: true
           script: |
-            unset DATABASE_URL
+            export SQLX_OFFLINE=true
             cargo build --bin et-migrate
             cargo run --bin et-migrate -- --config-file="config.github-actions.toml" migrate
 
@@ -74,5 +74,5 @@ jobs:
     with:
       flakes-from-devshell: true
       script: |
-        unset DATABASE_URL
+        export SQLX_OFFLINE=true
         cargo build

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ WORKDIR /usr/src/app
 
 COPY . .
 COPY --from=d3fk/tailwindcss:stable /tailwindcss /usr/local/bin/tailwindcss
+ENV SQLX_OFFLINE=true
 RUN cargo install --path .
 
 FROM debian:bookworm-slim

--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,8 @@
             ];
             shellHook = ''
               export PGDATA=$PWD/pgdata
-              export DATABASE_URL="postgres://et@localhost/et?sslmode=disable"
+              export PGDATABASE=et
+              export PGUSER=et
             '';
           };
         }


### PR DESCRIPTION
Setting in flake as the shell env can cause problems if an editor has a shell env that doesn't match this project. 

Move the DATABASE_URL to the .env that SQLX will explicitly load and avoid shell envvars