### PR TITLE
fix: Unlock sync / handle per-connection sync failure

### DIFF
--- a/.sqlx/query-0f5a796762a9fe943b796989485abe6d71e54e5176cf0559bec7779dcec7d8ad.json
+++ b/.sqlx/query-0f5a796762a9fe943b796989485abe6d71e54e5176cf0559bec7779dcec7d8ad.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT  pg_advisory_unlock($1)",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "pg_advisory_unlock",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "0f5a796762a9fe943b796989485abe6d71e54e5176cf0559bec7779dcec7d8ad"
+}


### PR DESCRIPTION
Any connection sync failure would end the process.

Don't fail out if one sync fails

Handle unlocking the advisory lock so a blocked process (maybe) doesn't lock globally.