### PR TITLE
fix: Include uniq constraint

### DIFF
--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -66,6 +66,7 @@ CREATE TABLE simplefin_account_transactions (
     transacted_at timestamptz,
     pending bool,
     description varchar NOT NULL,
+    UNIQUE (account_id, simplefin_id),
 
     CONSTRAINT simplefin_account_transactions_pkey PRIMARY KEY (id),
     CONSTRAINT simplefin_account FOREIGN KEY (account_id) REFERENCES simplefin_accounts (id)

--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -664,7 +664,7 @@ async fn sab_test(pool: PgPool) -> sqlx::Result<()> {
 
     let sfab2 = SFAccountBalance {
         account_id: account.id,
-        timestamp: now,
+        timestamp: now + chrono::Duration::days(1),
         balance: rust_decimal::Decimal::new(10000, 2),
     };
     sfab2.ensure_in_db(&pool).await.expect("Write to db");


### PR DESCRIPTION
Missing this constraint was creating schemas that would fail inserts

Add the constraint. Verified that `migrate` step will add it

```
ALTER TABLE simplefin_account_transactions ADD UNIQUE (account_id, simplefin_id)
```