### PR TITLE
chore: Update to postgres 17 for dev

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1729880355,
-        "narHash": "sha256-RP+OQ6koQQLX5nw0NmcDrzvGL8HDLnyXt/jHhL1jwjM=",
+        "lastModified": 1730170245,
+        "narHash": "sha256-PRq4vJjDa+m1mNwkV9H7zVzMhuMqsHJrTGx0iJZ0e0w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "18536bf04cd71abd345f9579158841376fdd0c5a",
+        "rev": "30c9efeef01e2ad4880bff6a01a61dd99536b3c9",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     rust-overlay.url = "github:oxalica/rust-overlay";
   };
@@ -19,7 +19,7 @@
             buildInputs = [
                 rust-bin.stable.latest.default
                 rust-analyzer
-                pkgs.postgresql_16
+                pkgs.postgresql_17
                 pkgs.foreman
                 pkgs.tailwindcss
                 pkgs.opentelemetry-collector


### PR DESCRIPTION
Use nixpkgs instead of nixstable

nixpkgs-unstable is recommended for this projects usecase: https://discourse.nixos.org/t/differences-between-nix-channels/13998