### PR TITLE
fix: Generate querystrings that can be parsed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -999,6 +999,7 @@ dependencies = [
  "rust-embed",
  "rust_decimal",
  "serde",
+ "serde_html_form",
  "serde_json",
  "serde_qs",
  "service_conventions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ chronoutil = "0.2.7"
 
 declare_schema = { version = "0.0.9" }
 charts-rs = "0.3.11"
+serde_html_form = "0.2.6"
 
 [patch.crates-io]
 # https://github.com/launchbadge/sqlx/pull/3553

--- a/src/charts.rs
+++ b/src/charts.rs
@@ -40,6 +40,7 @@ pub async fn get_chart(
     chart_options: Query<ChartOptions>,
     tx_filter: Query<crate::TransactionsFilterOptions>,
 ) -> Result<Response, crate::AppError> {
+    tracing::debug!("Chart Transaction Filter Options {:?}", &tx_filter);
     let d = crate::tx::SFAccountTXQuery::from_options_group_by(&tx_filter.deref(), &app_state.db)
         .await?;
     let vals_opt: Option<Vec<f32>> = d.clone().into_iter().map(|i| i.amount_f32()).collect();

--- a/src/main.rs
+++ b/src/main.rs
@@ -467,8 +467,8 @@ struct TransactionsFilterOptions {
 }
 
 impl TransactionsFilterOptions {
-    fn to_querystring(&self) -> Result<String, serde_qs::Error> {
-        let qs = serde_qs::to_string(&self)?;
+    fn to_querystring(&self) -> Result<String, serde_html_form::ser::Error> {
+        let qs = serde_html_form::to_string(&self)?;
         tracing::debug!(qs = qs, tfo= ?self, "To querystring");
         Ok(qs)
     }
@@ -728,5 +728,23 @@ where
 {
     fn from(err: E) -> Self {
         Self(err.into())
+    }
+}
+
+#[cfg(test)]
+mod test_transactions_filter_options {
+    use super::*;
+
+    #[test]
+    fn test_query_string() {
+        let tfo = TransactionsFilterOptions::default();
+        assert_eq!(tfo.to_querystring().unwrap(), "")
+    }
+    #[test]
+    fn test_query_string_label_list() {
+        let tfo = TransactionsFilterOptions::default()
+            .with_label("label1".to_string())
+            .unwrap();
+        assert_eq!(tfo.to_querystring().unwrap(), "labeled=label1")
     }
 }


### PR DESCRIPTION
The axum-extra query extractor was not able to parse the to_querystring result appropriately. The extractor looked for lists like a=1 a=2 a=3 to mean list a, with 3 elements.

serde_qs would generate that as a[0]=1 a[1]=2 a[2]=3.

Instead, use the same library internally that axum-extra does. This should ideally test with a request... but I added at least some tests!