### PR TITLE
fix: Failure to refresh user will let user login

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -608,10 +608,10 @@ async fn get_transactions_value(
 
 async fn root(
     State(app_state): State<AppState>,
-    user: Option<service_conventions::oidc::OIDCUser>,
+    user: Result<Option<service_conventions::oidc::OIDCUser>, service_conventions::oidc::OIDCUserError>,
     tx_filter: Query<TransactionsFilterOptions>,
 ) -> Result<Response, AppError> {
-    if let Some(_user) = user {
+    if let Ok(Some(_user)) = user {
         let filter_options = tx_filter.deref().clone();
         tracing::debug!(
             "Transaction Filter Options {:?}",


### PR DESCRIPTION
service_conventions attempts to refresh the user, but it may fail. In which case allow the user to login again instead of just displaying an error