### PR TITLE
fix: Include labels in rule creation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ rust-embed = { version = "8.3.0", features = ["axum", "mime-guess", "mime_guess"
 
 # Waiting on axum-embed > 0.1.0
 axum-embed = { git = "https://github.com/informationsea/axum-embed.git", ref = "f43a1c284fe41c5969bfcb9eae8fb85d8be0d3ff", version = "0.2.0"}
-axum-extra = { version = "0.11.0", features = ["query"] }
+axum-extra = { version = "0.11.0", features = ["form", "query"] }
 http = "1.1.0"
 serde_qs = "0.15.0"
 chronoutil = "0.2.7"

--- a/src/main.rs
+++ b/src/main.rs
@@ -570,18 +570,24 @@ impl TransactionsFilterOptions {
         let options: TransactionsFilterOptions = self.into();
         maud::html! {
 
-        @if let Some(txid) = options.transaction_id {
-            input type="hidden" name="transaction_id" value={(txid)} {}
-        }
-        @if let Some(account_id) = options.account_id {
-            input type="hidden" name="account_id" value={(account_id)} {}
-        }
-        @if let Some(fragment) = options.description_contains {
-            input type="hidden" name="description_contains" value={(fragment)} {}
-        }
-        @if let Some(start_datetime) = options.start_datetime {
-            input type="hidden" name="start_datetime" value={(start_datetime)} {}
-        }
+            @if let Some(txid) = options.transaction_id {
+                input type="hidden" name="transaction_id" value={(txid)} {}
+            }
+            @if let Some(account_id) = options.account_id {
+                input type="hidden" name="account_id" value={(account_id)} {}
+            }
+            @if let Some(fragment) = options.description_contains {
+                input type="hidden" name="description_contains" value={(fragment)} {}
+            }
+            @for as_labeled in options.labeled {
+                input type="hidden" name="labeled" value={(as_labeled)} {}
+            }
+            @for not_labeled in options.not_labeled {
+                input type="hidden" name="not_labeled" value={(not_labeled)} {}
+            }
+            @if let Some(start_datetime) = options.start_datetime {
+                input type="hidden" name="start_datetime" value={(start_datetime)} {}
+            }
         }
     }
 }
@@ -640,10 +646,7 @@ async fn root(
 ) -> Result<Response, AppError> {
     if let Ok(Some(_user)) = user {
         let filter_options = tx_filter.deref().clone();
-        tracing::debug!(
-            "Transaction Filter Options {:?}",
-            &filter_options.description_contains
-        );
+        tracing::debug!("Transaction Filter Options {:?}", &filter_options);
         let user_connections_f = Connection::connections(&app_state.db);
         let balances_f = accounts::SFAccountBalanceQueryResult::get_active_balances(&app_state.db);
         //let transactions_f =

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -3,14 +3,13 @@ use sqlx::postgres::PgPool;
 use crate::svg_icon;
 use crate::tx;
 use crate::TransactionsFilterOptions;
-use axum_extra::extract::Query;
+use axum_extra::extract::{Form, Query};
 use futures::try_join;
 use std::ops::Deref;
 
 use axum::{
     extract::{Path, State},
     response::{IntoResponse, Redirect, Response},
-    Form,
 };
 
 use crate::{html, AppState, Connection};
@@ -190,7 +189,6 @@ pub async fn handle_rules(
 
     let (user_connections, balances, rules_result) =
         try_join!(user_connections_f, balances_f, rules_fut)?;
-    let f = TransactionsFilterOptions::default();
 
     Ok(html::maud_page(html! {
           div class="flex flex-col lg:flex-row"{
@@ -325,7 +323,6 @@ pub async fn handle_new_rule_fragment(
     let name = "New Rule".to_string();
     let rule = Rule::try_new(name, filter_options.to_owned())?;
     rule.ensure_in_db(&app_state.db).await?;
-    let rules_result = RulesQuery::all(&app_state.db).await?;
 
     let rule_id = rule.id_string();
 


### PR DESCRIPTION
The labels were not read/passed through from  a transaction page so even if the view filtered correctly, the rule would not include the same filter options.