### PR TITLE
fix: Allow deleting  rule

### DIFF
--- a/.sqlx/query-ece8be74101f1ac40c1165052a508103933f380464600fc183466f644d95346f.json
+++ b/.sqlx/query-ece8be74101f1ac40c1165052a508103933f380464600fc183466f644d95346f.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                DELETE FROM rules\n                WHERE id = $1\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "ece8be74101f1ac40c1165052a508103933f380464600fc183466f644d95346f"
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -391,7 +391,10 @@ async fn main() {
         .route("/rules", get(rules::handle_rules))
         .route("/f/rules", get(rules::handle_rules_fragment))
         .route("/f/rules/new", post(rules::handle_new_rule_fragment))
-        .route("/rules/{rule_id}", get(rules::handle_rule))
+        .route(
+            "/rules/{rule_id}",
+            get(rules::handle_rule).delete(rules::handle_rule_delete),
+        )
         .route(
             "/f/rules/{rule_id}/labels/search",
             get(rules::handle_labels_search_fragment),


### PR DESCRIPTION
Allow deleting a rule, using HTMX confirmations

More should be done with modify rules, but this will allow easier cleanup than going into the DB. 

Closes #533